### PR TITLE
add rules for vm admin password to restrict minimum complexity with regex

### DIFF
--- a/add-nodes/src/main/arm/createUiDefinition.json
+++ b/add-nodes/src/main/arm/createUiDefinition.json
@@ -115,7 +115,9 @@
                                 },
                                 "toolTip": "Password for admin account of Virtual Machine",
                                 "constraints": {
-                                    "required": true
+                                    "required": true,
+                                    "regex": "^((?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{12,72}$",
+                                    "validationMessage": "Password must be at least 12 characters long and have 3 out of the following: one number, one lower case, one upper case, or one special character."
                                 }
                             },
                             {

--- a/arm-rhel-was-nd-cluster/src/main/arm/createUiDefinition.json
+++ b/arm-rhel-was-nd-cluster/src/main/arm/createUiDefinition.json
@@ -147,7 +147,9 @@
                                 },
                                 "toolTip": "Password for admin account of Virtual Machine",
                                 "constraints": {
-                                    "required": true
+                                    "required": true,
+                                    "regex": "^((?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])|(?=.*[0-9])(?=.*[a-z])(?=.*[!@#$%^&*])|(?=.*[0-9])(?=.*[A-Z])(?=.*[!@#$%^&*])|(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*])).{12,72}$",
+                                    "validationMessage": "Password must be at least 12 characters long and have 3 out of the following: one number, one lower case, one upper case, or one special character."
                                 }
                             },
                             {


### PR DESCRIPTION
- Issue: https://ms.portal.azure.com/#blade/HubsExtension/DeploymentDetailsBlade/overview/id/%2Fsubscriptions%2Fd87c774d-7de1-42ef-afb3-f7af5400e39a%2FresourceGroups%2Femily-test%2Fproviders%2FMicrosoft.Resources%2Fdeployments%2Fmicrosoft_javaeeonazure_test.20191212-arm-rhel-wa-20210119175118
- Reference solution: https://github.com/wls-eng/arm-oraclelinux-wls-admin/blob/develop/src/main/arm/createUiDefinition.json#L98-L99